### PR TITLE
Install Husky for git hooks (#5)

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "devDependencies": {
+        "husky": "^9.1.7",
         "vitest": "^2.1.8"
       }
     },
@@ -950,6 +951,22 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/loupe": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "test": "tests"
   },
   "scripts": {
-    "test": "vitest"
+    "test:watch": "vitest",
+    "test": "vitest run",
+    "prepare": "husky"
   },
   "keywords": [
     "workshop",
@@ -18,6 +20,7 @@
   "author": "Shreyash (WebDevCaptain)",
   "license": "MIT",
   "devDependencies": {
+    "husky": "^9.1.7",
     "vitest": "^2.1.8"
   }
 }


### PR DESCRIPTION
Husky comes with a default pre-commit hook that runs `npm test` before a commit is made.