### PR TITLE
Add caching for npm dependencies in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,12 @@ jobs:
         with:
           node-version: 22.12.0
 
+      - name: Cache npm dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+
       - name: Install dependencies
         run: npm ci
 


### PR DESCRIPTION
Cache npm dependencies if the `package-lock.json` file doesn't change.

It also looks after the runner (i.e. if OS changes, then cache is busted)

